### PR TITLE
Python version is added into setup.py with missing library name (rdflib)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Ontolearn is an open-source software library for explainable structured machine 
 ### Installation from source
 ```
 git clone https://github.com/dice-group/OntoPy.git
-conda create -n temp python=3.6.2
+conda create -n temp python=3.7.1
 conda activate temp
 pip install -e .
 python -c "import ontolearn"
+python -m pytest tests #
 ```
 ### Installation via pip
 
@@ -22,12 +23,8 @@ pip install ontolearn # https://pypi.org/project/ontolearn/ only a place holder.
 ## Usage
 See examples folder.
 
-## Test-Driven Development
-
-In this project, we follow the test-driven development process. 
-To this end, we strive for writing tests for each class under the test folder.
-We rely on the [pytest](https://docs.pytest.org) framework. 
-Executing ```pytest``` results in running all tests under the test folder.
+## Contribution
+Feel free to create a pull request. We will promptly review pull requests.
 
 ### Simple Linting and Testing
 

--- a/ontolearn/static_funcs.py
+++ b/ontolearn/static_funcs.py
@@ -133,3 +133,4 @@ def export_concepts(kb, concepts, path: str = 'concepts.owl', rdf_format: str = 
                 print(e)
                 print('exiting.')
     o1.save(file=path, format=rdf_format)
+    print('Concepts are saved.')

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,16 @@ setup(
                       'matplotlib',
                       'owlready2>=0.23',
                       'torch',
-                      'pandas'],
+                      'rdflib',
+                      'pandas',
+                      'pytest'
+                      ],
     author='Caglar Demir',
     author_email='caglardemir8@gmail.com',
     classifiers=[
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: MIT License", ],
-    python_requires='>=3.6',
+    python_requires='==3.7.1',
     long_description=long_description,
     long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
Installation tested. It works seamlessly.

```
git clone https://github.com/dice-group/OntoPy.git
conda create -n temp python=3.7.1
conda activate temp
pip install -e .
python -c "import ontolearn"
python -m pytest tests
```

Pytest and rdflib were missing in setup.py. They are added.