### PR TITLE
Relax max version constraint for scikit-learn dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pandas=1.2.3
   - pytorch=1.8.0
   - rdflib=6.0.2
-  - scikit-learn=0.24.1
+  - scikit-learn=1.0.2
   - sortedcontainers=2.4.0
   - owlready2=0.34
   - flask=1.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ scripts =
     ontolearn/endpoint/simple_drill_endpoint
 install_requires =
     typing_extensions; python_version < "3.7"
-    scikit-learn>=0.24.1,<1.0
+    scikit-learn>=0.24.1
     matplotlib>=3.3.4
     owlready2>=0.34
     torch>=1.7.1


### PR DESCRIPTION
I have a dependency conflict due to another library requiring a more recent `scikit-learn` version. Ontolearn seems to work fine with scikit learn 1.0. It seems like it's only used in two places directly:

https://github.com/dice-group/Ontolearn/blob/2fc128f068d2eeab9ae045bbc2278d13cbcef165/ontolearn/experiments.py#L7

https://github.com/dice-group/Ontolearn/blob/7d7d155ff21988ea2f0351b45cab17e5ef7e4bd5/ontolearn/utils/__init__.py#L78

So here's a suggestion to relax the max version constraint.