### PR TITLE
fix unexpected behaviour of DL Syntax Parser for Thing and Nothing

### DIFF
--- a/owlapy/parser.py
+++ b/owlapy/parser.py
@@ -722,9 +722,9 @@ class DLSyntaxParser(NodeVisitor, OWLObjectParser, metaclass=_DLSyntaxParserMeta
     def visit_class_iri(self, node, children) -> OWLClass:
         top_bottom = _node_text(node)
         if top_bottom == _DL_SYNTAX.TOP:
-            return OWLRDFVocabulary.OWL_THING.get_iri()
+            return OWLClass(OWLRDFVocabulary.OWL_THING.get_iri())
         elif top_bottom == _DL_SYNTAX.BOTTOM:
-            return OWLRDFVocabulary.OWL_NOTHING.get_iri()
+            return OWLClass(OWLRDFVocabulary.OWL_NOTHING.get_iri())
         else:
             return OWLClass(children[0])
 


### PR DESCRIPTION
The DLSyntax parser was implemented to return the IRIs of Thing and Nothing instead of the classes themselves. This was fixed by puting OWLClass to what was returned. Example,

Previous version returns: OWLRDFVocabulary.OWL_THING.get_iri()
Now it returns: OWLClass(OWLRDFVocabulary.OWL_THING.get_iri())