### PR TITLE
Few updates before new release

### DIFF
--- a/docs/usage/01_introduction.md
+++ b/docs/usage/01_introduction.md
@@ -1,6 +1,6 @@
 # Ontolearn
 
-**Version:** ontolearn 0.6.1
+**Version:** ontolearn 0.7.0
 
 **GitHub repository:** [https://github.com/dice-group/Ontolearn](https://github.com/dice-group/Ontolearn)
 

--- a/examples/example_knowledge_base.py
+++ b/examples/example_knowledge_base.py
@@ -38,7 +38,7 @@ for i in kb.all_individuals_set():
 print('*' * 100)
 
 # Direct concept hierarchy from Top to Bottom.
-for concept in kb.class_hierarchy().items():
+for concept in kb.class_hierarchy.items():
     print(f'{concept.get_iri().as_str()} => {[c.get_iri().as_str() for c in kb.get_direct_sub_concepts(concept)]}')
 print('*' * 100)
 

--- a/ontolearn/concept_learner.py
+++ b/ontolearn/concept_learner.py
@@ -791,6 +791,7 @@ class EvoLearner(BaseConceptLearner[EvoLearnerNode]):
         self.__setup()
 
     def __setup(self):
+        self._cache = dict()
         self.clean()
         if self.fitness_func is None:
             self.fitness_func = LinearPressureFitness()
@@ -810,7 +811,6 @@ class EvoLearner(BaseConceptLearner[EvoLearnerNode]):
         self._result_population = None
         self._dp_to_prim_type = dict()
         self._dp_splits = dict()
-        self._cache = dict()
         self._split_properties = []
 
         self.pset = self.__build_primitive_set()
@@ -1059,7 +1059,7 @@ class EvoLearner(BaseConceptLearner[EvoLearnerNode]):
             del creator.Quality
         except AttributeError:
             pass
-
+        self._cache.clear()
         super().clean()
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,10 @@
 from setuptools import setup, find_packages
+import re
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()
-setup(
-    name="ontolearn",
-    description="Ontolearn is an open-source software library for structured machine learning in Python. Ontolearn includes modules for processing knowledge bases, inductive logic programming and ontology engineering.",
-    version="0.6.2",
-    packages=find_packages(),
-    install_requires=[
-        "scikit-learn>=0.24.1",
+
+_deps = [
         "matplotlib>=3.3.4",
         "owlready2>=0.40",
         "torch>=1.7.1",
@@ -19,11 +15,44 @@ setup(
         "deap>=1.3.1",
         "httpx>=0.25.2",
         "tqdm>=4.64.0",
-        "transformers>=4.35.0",
+        "transformers>=4.38.1",
         "pytest>=7.2.2",
         "owlapy==0.1.1",
         "dicee==0.1.2",
-        "ontosample>=0.2.2"],
+        "ontosample>=0.2.2",
+        "gradio>=4.11.0"]
+
+deps = {b: a for a, b in (re.findall(r"^(([^!=<>~ ]+)(?:[!=<>~ ].*)?$)", x)[0] for x in _deps)}
+
+
+def deps_list(*pkgs):
+    return [deps[pkg] for pkg in pkgs]
+
+
+extras = dict()
+extras["min"] = deps_list(
+    "matplotlib",
+    "torch",
+    "rdflib",
+    "pandas",
+    "sortedcontainers",
+    "owlready2",
+    "owlapy",
+    "flask",  # Drill, NCES
+    "tqdm", "transformers",  # NCES
+    "dicee",  # Drill
+    "deap",  # Evolearner
+)
+
+extras["full"] = (extras["min"] + deps_list("httpx", "pytest", "gradio", "ontosample"))
+
+setup(
+    name="ontolearn",
+    description="Ontolearn is an open-source software library for structured machine learning in Python. Ontolearn includes modules for processing knowledge bases, inductive logic programming and ontology engineering.",
+    version="0.7.0",
+    packages=find_packages(),
+    install_requires=extras["min"],
+    extras_require=extras,
     author='Caglar Demir',
     author_email='caglardemir8@gmail.com',
     url='https://github.com/dice-group/Ontolearn',


### PR DESCRIPTION
- Updated ontology retrieval in `examples/example_knowledge_base.py`
- `clean` method [here](https://github.com/dice-group/Ontolearn/blob/ad3d318d1483829835962268dd355fe4fef9bd92/ontolearn/concept_learner.py#L1052) now cleans cache which means that cache is cleaned after each `fit` call. This is related with #337 and increased the performance significantly but still it does not give the expected result. 
- Added optional installation for ontolearn. ontolearn[min] by default and ontolearn[full] for full features. Let me know if we should restructure the default/optional libraries differently or even add more options.

_Increased the version for new release to 0.7.0_
