### PR TITLE
Bug fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,12 @@ Load an RDF knowledge graph
 ```shell
 ontolearn-webservice --path_knowledge_base KGs/Mutagenesis/mutagenesis.owl
 ```
-or launch a Tentris instance https://github.com/dice-group/tentris over Mutagenesis.
+or launch a triplestore server and load Mutagenesis there.
+Some leads to launch the triplestore server:
+- https://docs.tentris.io/binary/load.html
+- https://ontolearn-docs-dice-group.netlify.app/usage/04_knowledge_base#loading-and-launching-a-triplestore
 ```shell
-ontolearn-webservice --endpoint_triple_store http://0.0.0.0:9080/sparql
+ontolearn-webservice --endpoint_triple_store <your_triples_store_sparql_endpoint>
 ```
 The below code trains DRILL with 6 randomly generated learning problems
 provided that **path_to_pretrained_drill** does not lead to a directory containing pretrained DRILL.

--- a/docs/usage/01_introduction.md
+++ b/docs/usage/01_introduction.md
@@ -20,14 +20,14 @@ One of OntoLearn’s key contributions is its exclusive concept learning algorit
 Logics (DL). The library currently includes nine fully functional algorithms capable of learning complex concepts in DL. 
 For further details and references, relevant research papers can be found [here](09_further_resources.md).
 
-At the core of OntoLearn lies [Owlapy]((https://github.com/dice-group/owlapy)), a Python package inspired by the OWL API (its Java counterpart) and developed by 
+At the core of OntoLearn lies [Owlapy](https://github.com/dice-group/owlapy), a Python package inspired by the OWL API (its Java counterpart) and developed by 
 the OntoLearn team. To enhance modularity, readability, and maintainability, we have separated Owlapy from Ontolearn into an 
 independent repository. This modular approach allows Owlapy to serve not only as a framework for representing OWL 2 
 entities, but also as a tool for ontology manipulation and reasoning.
 
 ---------------------------------------
 
-**Ontolearn (including owlapy and ontosample) can do the following:**
+**Ontolearn (including [owlapy](https://github.com/dice-group/owlapy) and [ontosample](https://github.com/alkidbaci/OntoSample)) can do the following:**
 
 - **Use concept learning algorithms to generate hypotheses for classifying positive examples in a learning problem**.
 - **Use local datasets or datasets that are hosted on a triplestore server, for the learning task.**

--- a/ontolearn/scripts/run.py
+++ b/ontolearn/scripts/run.py
@@ -86,7 +86,7 @@ def get_drill(data: dict):
     else:
         # remove the pretrained directory if already exist but does not have the drill.pth file and retrain
         if data.get("path_to_pretrained_drill", None) and os.path.isdir(data["path_to_pretrained_drill"]):
-            shutil.rmtree('path_to_pretrained_drill')
+            shutil.rmtree(data['path_to_pretrained_drill'])
         # Train & Save
         drill.train(num_of_target_concepts=data.get("num_of_target_concepts", 1),
                     num_learning_problems=data.get("num_of_training_learning_problems", 1))

--- a/ontolearn/triple_store.py
+++ b/ontolearn/triple_store.py
@@ -132,11 +132,13 @@ def send_http_request_to_ts_and_fetch_results(triplestore_address: str, query: s
         # return [return_type(IRI.create(i['x']['value'])) for i in
         #         response.json()['results']['bindings']]
     except JSONDecodeError as e:
-        raise JSONDecodeError(
-            f"Something went wrong with decoding JSON from the response. Check for typos in "
-            f"the `triplestore_address` = '{triplestore_address}' otherwise the error is likely "
-            f"caused by an internal issue. \n  -->Error: {e}"
-        )
+        raise RuntimeError(
+            f"Something went wrong with decoding JSON from the response. "
+            f"Check for typos in the `triplestore_address` = '{triplestore_address}' "
+            f"otherwise the error is likely caused by an internal issue."
+            f"\n  -->Error: {e}"
+            f"\n Response text: {response.text}"
+        ) from e
 
 
 def unwrap(result: Response):


### PR DESCRIPTION
Running ontolearn webservice via triplestore endpoint was having issues which are now fixed. 

Details:
- Drill "path_to_pretrained_drill" had to be accessed from `data`
-  JSONDecodeError needs 2 additional arguments, changed to RuntimeError. `response.text` added to error message for better tracking if any issue arises in the future.

Took the opportunity to fix a bug with the link of owlapy in the docs.