### PR TITLE
Fix: Ensure Drill stops when max_num_of_concepts_tested is reached

### DIFF
--- a/ontolearn/learners/drill.py
+++ b/ontolearn/learners/drill.py
@@ -358,6 +358,9 @@ class Drill(RefinementBasedConceptLearner):  # pragma: no cover
             # (6.2) Checking the runtime termination criterion.
             if time.time() - self.start_time > self.max_runtime:
                 return self.terminate()
+            # (6.2.1) Checking the max_num_of_concepts_tested termination criterion.
+            if self._number_of_tested_concepts >= self.max_num_of_concepts_tested:
+                return self.terminate()
             # (6.3) Refine (6.1)
             # Convert this into tqdm with an update ?!
             for ref in (tqdm_bar := make_iterable_verbose(self.apply_refinement(most_promising),
@@ -365,6 +368,9 @@ class Drill(RefinementBasedConceptLearner):  # pragma: no cover
                                                           position=0, leave=True)):
                 # (6.3.1) Checking the runtime termination criterion.
                 if time.time() - self.start_time > self.max_runtime:
+                    break
+                # (6.3.1.1) Checking the max_num_of_concepts_tested termination criterion.
+                if self._number_of_tested_concepts >= self.max_num_of_concepts_tested:
                     break
                 # (6.3.2) Compute the quality stored in the RL state
                 self.compute_quality_of_class_expression(ref)

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -68,3 +68,33 @@ class TestDrill(unittest.TestCase):
                   f"Test Quality: {test_f1_drill:.3f} \n")
         print(total_test_f1/5)
         assert total_test_f1/5 >= 0.8
+
+    def test_max_num_of_concepts_tested(self):
+        """Test that DRILL stops when max_num_of_concepts_tested is reached."""
+        kb = KnowledgeBase(path=self.kg_path)
+        max_concepts = 10
+        drill = Drill(knowledge_base=kb,
+                      path_embeddings=self.embeddings_path,
+                      refinement_operator=LengthBasedRefinement(knowledge_base=kb),
+                      quality_func=F1(),
+                      reward_func=CeloeBasedReward(),
+                      epsilon_decay=.01,
+                      learning_rate=.01,
+                      num_of_sequential_actions=1,
+                      num_episode=1,
+                      iter_bound=10_000,
+                      max_runtime=300,
+                      max_num_of_concepts_tested=max_concepts)
+
+        with open(self.lp_path) as json_file:
+            examples = json.load(json_file)
+        p = examples["problems"]["Uncle"]['positive_examples']
+        n = examples["problems"]["Uncle"]['negative_examples']
+
+        train_lp = PosNegLPStandard(pos=set(map(OWLNamedIndividual, map(IRI.create, p))),
+                                    neg=set(map(OWLNamedIndividual, map(IRI.create, n))))
+
+        drill.fit(train_lp)
+        # Verify that the number of tested concepts does not exceed the limit
+        assert drill.number_of_tested_concepts <= max_concepts, \
+            f"Expected at most {max_concepts} concepts tested, but got {drill.number_of_tested_concepts}"


### PR DESCRIPTION
- Added termination check at the start of each iteration in the fit loop
- Added termination check inside the refinement loop
- Added test case for max_num_of_concepts_tested feature