### PR TITLE
Learning problem generator issue_576

### DIFF
--- a/ontolearn/search.py
+++ b/ontolearn/search.py
@@ -347,7 +347,7 @@ class NCESNode(_NodeConcept, _NodeLen, _NodeIndividualsCount, _NodeQuality, Abst
 class RL_State(_NodeConcept, _NodeQuality, _NodeHeuristic, AbstractNode, _NodeParentRef['RL_State']):
     renderer: ClassVar[OWLObjectRenderer] = DLSyntaxObjectRenderer()
     """RL_State node."""
-    __slots__ = '_concept', 'embeddings', '_quality', '_heuristic', 'length', 'parent_node', 'is_root', '_parent_ref', '__weakref__'
+    __slots__ = '_concept', 'embeddings', '_quality', '_heuristic', 'length', 'parent_node', 'is_root', '_parent_ref', '__weakref__', 'instances'
 
     def __init__(self, concept: OWLClassExpression, parent_node: Optional['RL_State'] = None,
                  embeddings=None, is_root: bool = False, length=None):

--- a/tests/test_learning_problem_generator.py
+++ b/tests/test_learning_problem_generator.py
@@ -20,7 +20,7 @@ class LearningProblemGenerator_Test(unittest.TestCase):
 
     def test_get_balanced_n_samples_per_example(self):
         lp = LearningProblemGenerator(knowledge_base=kb)
-        """
+        
         # @Using it with LengthBasedRefinement leads to extesive comp. time 
         min_num_concepts = 10
         max_length = 5
@@ -40,7 +40,7 @@ class LearningProblemGenerator_Test(unittest.TestCase):
             # Let Person be a target concept and let 10 be the number instances belonging to Person in CWR.
             # If we sample 5 individuals from Person, then there is no guarantee sampled E^+ nor E^- be same.
             # self.assertNotEqual(balanced_examples[i][2], balanced_examples[i + 1][2])
-        """
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes Issue#576 Learning Problem Generator not working due to  AttributeError: 'RL_State' object has no attribute 'instances'

in search.py 'instances' was missing as a __slots__ argument of RL_State class

Also re-enabled the corresponding test file, which is now passing.