### PR TITLE
Migrate to owlapy 1.6.6 (owlready2 now an optional extra)

### DIFF
--- a/ontolearn/incomplete_kb.py
+++ b/ontolearn/incomplete_kb.py
@@ -21,9 +21,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # -----------------------------------------------------------------------------
-from owlready2 import *
 import random
 from typing import Set
+
+from ontolearn.utils import import_owlready2
 
 
 def make_kb_incomplete_ass(kb_path, output_path, rate, seed):
@@ -46,9 +47,11 @@ def make_kb_incomplete_ass(kb_path, output_path, rate, seed):
 
     random.seed(seed)
 
+    owlready2 = import_owlready2()
+
     # Load the ontology
-    kb = get_ontology(kb_path).load()
-    
+    kb = owlready2.get_ontology(kb_path).load()
+
     # Get all individuals in the ontology
     all_individuals = list(kb.individuals())
     
@@ -98,21 +101,23 @@ def make_kb_incomplete(kb_path, output_path, rate, seed)-> Set[str]:
 
     random.seed(seed)
 
+    owlready2 = import_owlready2()
+
     # Load the ontology
-    kb = get_ontology(kb_path).load()
-    
+    kb = owlready2.get_ontology(kb_path).load()
+
     # Get all individuals (instances) in the ABox
     all_individuals = list(kb.individuals())
-    
+
     # Calculate the number of individuals to remove based on the rate
     num_to_remove = int(len(all_individuals) * (rate / 100))
-    
+
     # Randomly select individuals to remove
     individuals_to_remove = random.sample(all_individuals, num_to_remove)
-    
+
     # Remove the selected individuals
     for individual in individuals_to_remove:
-        destroy_entity(individual)
+        owlready2.destroy_entity(individual)
     
     # Save the modified ontology to a new file
     kb.save(file=output_path, format="rdfxml")
@@ -132,9 +137,11 @@ def make_kb_inconsistent(kb_path, output_path, rate, seed, max_attempts=100):
     
     # Set the random seed for reproducibility
     random.seed(seed)
-    
+
+    owlready2 = import_owlready2()
+
     # Load the ontology
-    onto = get_ontology(kb_path).load()
+    onto = owlready2.get_ontology(kb_path).load()
 
     # Get all individuals, classes, and properties
     all_individuals = list(onto.individuals())

--- a/ontolearn/semantic_caching.py
+++ b/ontolearn/semantic_caching.py
@@ -47,12 +47,14 @@ from owlapy import owl_expression_to_dl
 from itertools import chain
 import os
 import random
+import re
 import itertools
-from owlready2 import *
 from collections import OrderedDict
 from owlapy.owl_reasoner import SyncReasoner
 import pickle
 from tqdm import tqdm
+
+from ontolearn.utils import import_owlready2
 
 
 def concept_generator(path_kg):
@@ -320,7 +322,7 @@ def semantic_caching_size(func, cache_size, eviction_strategy, random_seed, cach
         # Load ontology and individuals if not already cached
         path_onto = args[1]
         if path_onto not in loaded_ontologies:
-            loaded_ontologies[path_onto] = get_ontology(path_onto).load()
+            loaded_ontologies[path_onto] = import_owlready2().get_ontology(path_onto).load()
             loaded_individuals[path_onto] = {a.iri for a in list(loaded_ontologies[path_onto].individuals())}
         onto = loaded_ontologies[path_onto]
         All_individuals = loaded_individuals[path_onto]

--- a/ontolearn/tentris.py
+++ b/ontolearn/tentris.py
@@ -37,7 +37,8 @@ from owlapy.owl_axiom import OWLDataPropertyRangeAxiom, OWLObjectPropertyRangeAx
 from owlapy.owl_individual import OWLNamedIndividual
 from owlapy.owl_literal import OWLLiteral
 from owlapy.owl_object import OWLEntity
-from owlapy.owl_ontology import OWLOntology, OWLOntologyID, _M
+from owlapy.abstracts import AbstractOWLOntology
+from owlapy.owl_ontology import OWLOntologyID
 from owlapy.owl_property import OWLObjectPropertyExpression, OWLObjectProperty, OWLDataProperty
 
 from ontolearn.knowledge_base import KnowledgeBase
@@ -51,7 +52,7 @@ from ontolearn.utils import oplogging, Factory
 from ontolearn.base.ext import OWLReasonerEx
 from ontolearn.base import OntologyManager, OntologyReasoner
 from owlapy.render import ManchesterOWLSyntaxOWLObjectRenderer, DLSyntaxObjectRenderer
-from owlapy.util import LRUCache
+from owlapy.utils import LRUCache
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ class EncodedPosNegLPStandardTentris(EncodedPosNegLPStandardKind):
         return f'EncodedPosNegLPStandardTentris(id={self.id})'
 
 
-class TentrisOntology(OWLOntology):
+class TentrisOntology(AbstractOWLOntology):
     __slots__ = '_path', '_endpoint_url', '_backing_mgr', '_backing_onto', '_endpoint_timeout'
 
     def __init__(self, path: str, endpoint_url: str, timeout: float):
@@ -130,7 +131,7 @@ class TentrisOntology(OWLOntology):
         logger.debug("Calling object_property_range_axioms from backing onto")
         yield from self._backing_onto.object_property_range_axioms(property)
 
-    def get_owl_ontology_manager(self) -> _M:
+    def get_owl_ontology_manager(self) -> OntologyManager:
         raise NotImplementedError
 
     def get_ontology_id(self) -> OWLOntologyID:

--- a/ontolearn/utils/__init__.py
+++ b/ontolearn/utils/__init__.py
@@ -36,6 +36,7 @@ from owlapy.owl_individual import OWLNamedIndividual
 from ontolearn.utils.log_config import setup_logging  # noqa: F401
 import pandas as pd
 from .static_funcs import compute_f1_score, f1_set_similarity, concept_reducer, concept_reducer_properties
+from ._lazy_owlready2 import import_owlready2  # noqa: F401
 
 Factory = Callable
 from typing import Set

--- a/ontolearn/utils/_lazy_owlready2.py
+++ b/ontolearn/utils/_lazy_owlready2.py
@@ -1,0 +1,46 @@
+# -----------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2024 Ontolearn Team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -----------------------------------------------------------------------------
+
+"""Optional owlready2 dependency shim.
+
+owlapy no longer depends on owlready2 at install time (it's an optional extra,
+``pip install owlapy[owlready2]`` -- see dice-group/owlapy#205), and Ontolearn doesn't
+declare a direct dependency on it either. ``ontolearn.incomplete_kb`` and
+``ontolearn.semantic_caching`` still use owlready2 directly, so they import it lazily through
+``import_owlready2()`` instead of at module load, raising a clear, actionable error only when
+code actually tries to use it.
+"""
+
+
+def import_owlready2():
+    """Import ``owlready2`` if installed, else raise a clear, actionable ``ImportError``."""
+    try:
+        import owlready2
+        return owlready2
+    except ImportError as e:
+        raise ImportError(
+            "owlready2 is required for this operation but is not installed. owlready2 is an "
+            "optional dependency of owlapy -- install it with `pip install owlready2>=0.40` or "
+            "`pip install owlapy[owlready2]`."
+        ) from e

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ _deps = [
     "tqdm>=4.64.0",
     "transformers>=4.38.1",
     "pytest>=7.2.2",
-    "owlapy==1.6.3",
+    "owlapy==1.6.6",
     "dicee==0.3.2",
     "ontosample>=0.2.2",
     "sphinx>=7.2.6",


### PR DESCRIPTION
## Summary
- Bump the `owlapy==1.6.3` pin in `setup.py` to `1.6.6`, the release that makes `owlready2` an optional install extra (`pip install owlapy[owlready2]`) instead of a hard dependency (dice-group/owlapy#205).
- `ontolearn/incomplete_kb.py`/`ontolearn/semantic_caching.py` did `from owlready2 import *` at module load, which would now crash on import for anyone without `owlready2` installed. Added `ontolearn.utils.import_owlready2()` (in a new `ontolearn/utils/_lazy_owlready2.py`) and switched both files to import lazily, raising an actionable `ImportError` only when owlready2-backed functionality is actually called.
- `ontolearn/tentris.py` imported `owlapy.owl_ontology.OWLOntology`/`_M` and `owlapy.util`, renamed to `owlapy.abstracts.AbstractOWLOntology` and `owlapy.utils` back in owlapy 1.1.0. Fixed per #599's suggestion.

## Notes
- `tentris.py` still can't fully import after this fix — it separately references `ontolearn.base`, which was deleted in a 2024 commit ("Adaptation to owlapy 1.1.0 (base module removed)"). The file is self-marked `# TODO: Stale script! Should be updated or removed!` and isn't imported anywhere else in the codebase, so that deeper rewrite is left out of scope here; #599's specific import fixes are applied.
- Manually smoke-tested `incomplete_kb.py` (`make_kb_incomplete`, `make_kb_inconsistent`) and `semantic_caching.py` (`run_semantic_cache`) end-to-end against `KGs/Family/father.owl` since `tests/test_semantic_cache.py` is fully commented out (no automated coverage).

Closes #600, #599

## Test plan
- [x] `pytest tests/test_static_funcs.py tests/test_knowledge_base.py tests/test_concept.py` — pass
- [x] Full suite: `pytest -p no:warnings --continue-on-collection-errors` — 49 passed, 10 subtests passed, 0 failures. The 21 collection errors are all one pre-existing, unrelated root cause in this dev environment (`transformers==4.42.4` requires `tokenizers<0.20`, but `tokenizers==0.23.1` is installed) that blocks any test file importing `ontolearn.learners`; not caused by this change.
- [ ] Re-run in a clean environment with matching `transformers`/`tokenizers` versions to confirm the learner-family tests (`test_celoe.py`, `test_tdl.py`, etc.) also pass under owlapy 1.6.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAArxHvomYuQmzjbMiV8d4