### PR TITLE
Fix AttributeError in DRILLSearchTreePriorityQueue.get_top_n

### DIFF
--- a/ontolearn/search.py
+++ b/ontolearn/search.py
@@ -795,8 +795,7 @@ class DRILLSearchTreePriorityQueue(DRILLAbstractTree):
         -------
         top_n_predictions: A list of node objects
         """
-        all_nodes = self.refined_nodes + self.nodes.values()
-        all_nodes.union(self.nodes)
+        all_nodes = list(self.nodes.values())
 
         if key == 'quality':
             top_n_predictions = sorted(all_nodes, key=lambda node: node.quality, reverse=True)[:n]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,49 @@
+import unittest
+
+from owlapy.class_expression import OWLClass
+from owlapy.iri import IRI
+
+from ontolearn.search import DRILLSearchTreePriorityQueue, RL_State
+
+
+def _make_state(name: str, quality: float, heuristic: float) -> RL_State:
+    # Each node needs a distinct concept: RL_State/DRILLSearchTreePriorityQueue
+    # key nodes by their DL string representation, so identical concepts would
+    # collapse into a single tree entry.
+    concept = OWLClass(IRI.create(f'http://example.com/{name}'))
+    state = RL_State(concept, is_root=True)
+    state.quality = quality
+    state.heuristic = heuristic
+    return state
+
+
+class DRILLSearchTreePriorityQueueTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tree = DRILLSearchTreePriorityQueue(verbose=0)
+        self.tree.add(_make_state('A', quality=0.2, heuristic=0.9))
+        self.tree.add(_make_state('B', quality=0.8, heuristic=0.1))
+        self.tree.add(_make_state('C', quality=0.5, heuristic=0.5))
+
+    def test_get_top_n_does_not_raise(self):
+        # Regression test for ontolearn/search.py:798, where get_top_n()
+        # referenced the never-assigned self.refined_nodes and tried to
+        # add it to a dict_values object, raising AttributeError/TypeError.
+        top_n = self.tree.get_top_n(2, key='quality')
+        self.assertEqual(len(top_n), 2)
+
+    def test_get_top_n_orders_by_quality(self):
+        top_n = self.tree.get_top_n(3, key='quality')
+        self.assertEqual([node.quality for node in top_n], [0.8, 0.5, 0.2])
+
+    def test_get_top_n_orders_by_heuristic(self):
+        top_n = self.tree.get_top_n(3, key='heuristic')
+        self.assertEqual([node.heuristic for node in top_n], [0.9, 0.5, 0.1])
+
+    def test_get_top_n_limits_result_size(self):
+        top_n = self.tree.get_top_n(1, key='quality')
+        self.assertEqual(len(top_n), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes item 1 in Improvements.md: `DRILLSearchTreePriorityQueue.get_top_n()` (`ontolearn/search.py:798`) referenced `self.refined_nodes`, an attribute that is never assigned anywhere in the codebase, and attempted `+` on a `dict_values` object — both raise at runtime (`AttributeError`/`TypeError`) any time this method is called.
- Replaced with `all_nodes = list(self.nodes.values())` and removed the subsequent no-op `all_nodes.union(self.nodes)` call, whose result was discarded and which would also fail since `list` has no `.union()` method.
- Added `tests/test_search.py` with regression tests for `get_top_n()` covering the `quality`, `heuristic`, and result-size-limiting behavior.

## Test plan
- [x] `pytest tests/test_search.py -p no:warnings -v` passes on this branch
- [x] Confirmed the new tests fail with `AttributeError: 'DRILLSearchTreePriorityQueue' object has no attribute 'refined_nodes'` against the pre-fix version of `ontolearn/search.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)