### PR TITLE
Reconcile Improvements.md and CHANGELOG.md with merged fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ date) and use that section as the basis for the GitHub release notes.
   by default, matching the other learners. (#585)
 
 ### Fixed
+- `DRILLSearchTreePriorityQueue.get_top_n()` raised `AttributeError`/`TypeError`
+  on the never-assigned `self.refined_nodes` attribute; now builds its node
+  list from `self.nodes.values()`. (#605)
+- `LengthBasedRefinement.refine_atomic_concept`'s disjointness check was dead
+  logic — both branches of the `if`/`else` built the same expression, so
+  refinements into a class disjoint with the current concept were never
+  actually skipped. (#604)
 - `LearningProblemGenerator` was not working; `tests/test_learning_problem_generator.py`
   re-enabled. (#589)
 - TDL++ integer-typed expression handling; two more intervals added to range

--- a/Improvements.md
+++ b/Improvements.md
@@ -10,16 +10,6 @@ Prioritized roughly high → low impact within each section.
 These are actual defects, not style nits — worth fixing regardless of any
 broader refactor.
 
-- **`ontolearn/search.py:798`** — `DRILLSearchTreePriorityQueue.get_top_n()`
-  does `self.refined_nodes + self.nodes.values()`. `self.refined_nodes` is
-  never assigned anywhere in the codebase, and `dict_values` doesn't support
-  `+` anyway — this raises `AttributeError`/`TypeError` if the method is ever
-  called. Fix: `list(self.nodes.values())`.
-- **`ontolearn/refinement_operators.py:173-178`** —
-  `LengthBasedRefinement.refine_atomic_concept`: the `if`/`else` branches
-  yield the exact same expression, so the disjointness check on line 175 is
-  dead logic with no effect. Either differentiate the branches or drop the
-  conditional.
 - **`ontolearn/learners/tree_learner.py:441`** — the "no features extracted"
   error message references `self.use_data_properties`, an attribute
   `TDL.__init__` never sets (only `use_data_properties_boolean/string/date/numeric`
@@ -192,7 +182,8 @@ broader refactor.
 
 ## Suggested priority order
 
-1. Fix the five correctness bugs in §1 (cheap, high-value, some are one-liners).
+1. Fix the remaining three correctness bugs in §1 (cheap, high-value, some are
+   one-liners).
 2. Fix the two mutable-default-argument bugs in §4 (cheap, real risk).
 3. Delete or restore the two fully-commented-out test files in §6.
 4. Tackle the `tree_learner_refinement_inherit.py` duplication in §2 as a


### PR DESCRIPTION
## Summary
- #605 and #604 each fixed one of the correctness bugs listed in `Improvements.md` §1, but the follow-up bookkeeping was missed: the items weren't removed from `Improvements.md` and the fixes weren't recorded in `CHANGELOG.md`.
- Removes the now-fixed `ontolearn/search.py:798` and `ontolearn/refinement_operators.py:173-178` bullets from `Improvements.md` §1, and updates the "Suggested priority order" count from five to three remaining correctness bugs.
- Adds `CHANGELOG.md` entries under `### Fixed` for both PRs.

## Test plan
- [x] Docs-only change; no code touched.
- [x] Diffed against `Improvements.md`/`CHANGELOG.md` to confirm only the two already-merged items were removed/recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)