### PR TITLE
Fix EvoLearner clobbering DEAP creator types across concurrent instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ date) and use that section as the basis for the GitHub release notes.
   `_enforce` repaired malformed token sequences via `random.choice(...)`, making
   parser output non-deterministic across runs on identical input; replaced with
   a deterministic (sorted) tie-break.
+- `EvoLearner` registered its DEAP `Fitness`/`Quality`/`Individual` types under
+  fixed names in DEAP's process-global `creator` module and tore them down in
+  `clean()` behind a bare `except AttributeError: pass`; concurrent
+  `EvoLearner` instances (e.g. `fit()` calls interleaved across threads) could
+  silently clobber each other's DEAP type definitions. Each instance now
+  registers its own uniquely-named types. (#609)
 - `DRILLSearchTreePriorityQueue.get_top_n()` raised `AttributeError`/`TypeError`
   on the never-assigned `self.refined_nodes` attribute; now builds its node
   list from `self.nodes.values()`. (#605)

--- a/Improvements.md
+++ b/Improvements.md
@@ -16,12 +16,6 @@ broader refactor.
   exist). Hitting this branch raises `AttributeError` instead of the intended
   descriptive error, hiding the real problem from users. (`TDL_refinement`
   does define this attribute, so only the base `TDL` class is affected.)
-- **`ontolearn/learners/evolearner.py:312-314,472-479`** — DEAP's `creator`
-  module is process-global; `EvoLearner` registers `Fitness`/`Quality`/
-  `Individual` types into it and tears them down in `clean()` behind a bare
-  `except AttributeError: pass`. Two `EvoLearner` instances used concurrently,
-  or `fit()` calls interleaved across threads, will clobber each other's DEAP
-  type definitions. Not thread-safe, and the failure mode is silent.
 
 ## 2. Code duplication
 
@@ -176,8 +170,8 @@ broader refactor.
 
 ## Suggested priority order
 
-1. Fix the remaining two correctness bugs in §1 (cheap, high-value, some are
-   one-liners).
+1. Fix the remaining correctness bug in §1 (cheap, high-value, likely a
+   one-liner).
 2. Fix the two mutable-default-argument bugs in §4 (cheap, real risk).
 3. Delete or restore the two fully-commented-out test files in §6.
 4. Tackle the `tree_learner_refinement_inherit.py` duplication in §2 as a

--- a/ontolearn/learners/evolearner.py
+++ b/ontolearn/learners/evolearner.py
@@ -26,6 +26,7 @@
 
 import operator
 import time
+import uuid
 from itertools import chain
 from typing import Any, Callable, Dict, FrozenSet, List, Tuple, Iterable, Optional, Union
 
@@ -87,7 +88,8 @@ class EvoLearner(BaseConceptLearner):
     __slots__ = 'fitness_func', 'init_method', 'algorithm', 'value_splitter', 'tournament_size', \
         'population_size', 'num_generations', 'height_limit', 'use_data_properties', 'pset', 'toolbox', \
         '_learning_problem', '_result_population', 'mut_uniform_gen', '_dp_to_prim_type', '_dp_splits', \
-        '_split_properties', '_cache', 'use_card_restrictions', 'card_limit', 'use_inverse', 'total_fits', 'generator'
+        '_split_properties', '_cache', 'use_card_restrictions', 'card_limit', 'use_inverse', 'total_fits', \
+        'generator', '_creator_uid'
 
     name = 'evolearner'
 
@@ -190,6 +192,11 @@ class EvoLearner(BaseConceptLearner):
         self.height_limit = height_limit
         self.total_fits = 0
         self.generator = ConceptGenerator()
+        # DEAP's `creator` module is process-global, so plain names like "Fitness"/
+        # "Individual" would be clobbered by any other EvoLearner instance created or
+        # fit()-ed concurrently. Suffix them with a per-instance uid to keep instances
+        # isolated from each other.
+        self._creator_uid = uuid.uuid4().hex
         self.__setup()
 
     def __setup(self):
@@ -308,14 +315,27 @@ class EvoLearner(BaseConceptLearner):
                          name=escape(self.generator.nothing.str))
         return pset
 
+    def __creator_class_names(self) -> Tuple[str, str, str]:
+        """Per-instance names for the DEAP `creator` types this learner registers, to avoid
+        clobbering another EvoLearner instance's types in DEAP's process-global `creator`
+        module."""
+        return (f"Fitness_{self._creator_uid}", f"Quality_{self._creator_uid}",
+               f"Individual_{self._creator_uid}")
+
     def __build_toolbox(self) -> base.Toolbox:
-        creator.create("Fitness", base.Fitness, weights=(1.0,))
-        creator.create("Quality", base.Fitness, weights=(1.0,))
-        creator.create("Individual", gp.PrimitiveTree, fitness=creator.Fitness, quality=creator.Quality)
+        fitness_name, quality_name, individual_name = self.__creator_class_names()
+        if not hasattr(creator, fitness_name):
+            creator.create(fitness_name, base.Fitness, weights=(1.0,))
+        if not hasattr(creator, quality_name):
+            creator.create(quality_name, base.Fitness, weights=(1.0,))
+        if not hasattr(creator, individual_name):
+            creator.create(individual_name, gp.PrimitiveTree,
+                           fitness=getattr(creator, fitness_name),
+                           quality=getattr(creator, quality_name))
 
         toolbox = base.Toolbox()
         toolbox.register(ToolboxVocabulary.INIT_POPULATION.value, self.init_method.get_population,
-                         creator.Individual, self.pset)
+                         getattr(creator, individual_name), self.pset)
         toolbox.register(ToolboxVocabulary.COMPILE.value, gp.compile, pset=self.pset)
 
         toolbox.register(ToolboxVocabulary.FITNESS_FUNCTION.value, self._fitness_func)
@@ -470,13 +490,14 @@ class EvoLearner(BaseConceptLearner):
             self._number_of_tested_concepts += 1
 
     def clean(self, partial: bool = False):
-        # Resets classes if they already exist, names must match the ones that were created in the toolbox
-        try:
-            del creator.Fitness
-            del creator.Individual
-            del creator.Quality
-        except AttributeError:
-            pass
+        # Resets classes if they already exist, names must match the ones that were created in the toolbox.
+        # Only this instance's own uid-suffixed names are touched, so concurrent EvoLearner
+        # instances never clobber each other's DEAP `creator` types.
+        for name in self.__creator_class_names():
+            try:
+                delattr(creator, name)
+            except AttributeError:
+                pass
         super().clean()
         if not partial:
             # Reset everything if fitting more than one lp. Tests have shown that this is necessary to get the

--- a/tests/test_evolearner.py
+++ b/tests/test_evolearner.py
@@ -62,6 +62,42 @@ class TestEvoLearner(unittest.TestCase):
         best_pred = returned_model.best_hypotheses(n=1, return_node=True)
         assert best_pred.quality == 1.00
 
+    def test_concurrent_instances_do_not_clobber_deap_creator_types(self):
+        # Regression test: EvoLearner used to register DEAP's `Fitness`/`Quality`/`Individual`
+        # types under fixed names into DEAP's process-global `creator` module, so two
+        # `EvoLearner` instances fitting concurrently (e.g. from different threads) could
+        # clobber each other's types, and `clean()`'s bare `except AttributeError: pass`
+        # could silently delete a type another still-running instance depended on.
+        import threading
+
+        with open('examples/synthetic_problems.json') as json_file:
+            settings = json.load(json_file)
+        kb = KnowledgeBase(path=settings['data_path'][3:])
+
+        problems = list(settings['problems'].items())[:2]
+        results = {}
+        errors = []
+
+        def run(str_target_concept, examples):
+            try:
+                model = EvoLearner(knowledge_base=kb, max_runtime=10, population_size=50, num_generations=5)
+                pos = set(map(OWLNamedIndividual, map(IRI.create, set(examples['positive_examples']))))
+                neg = set(map(OWLNamedIndividual, map(IRI.create, set(examples['negative_examples']))))
+                lp = PosNegLPStandard(pos=pos, neg=neg)
+                model.fit(learning_problem=lp)
+                results[str_target_concept] = model.best_hypotheses(n=1, return_node=True).quality
+            except Exception as e:
+                errors.append((str_target_concept, e))
+
+        threads = [threading.Thread(target=run, args=(name, examples)) for name, examples in problems]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"concurrent EvoLearner fit() raised: {errors}"
+        assert len(results) == len(problems)
+
     def test_example(self):
 
         with open('examples/synthetic_problems.json') as json_file:


### PR DESCRIPTION
DEAP's `creator` module is process-global. EvoLearner registered its Fitness/Quality/Individual types under fixed names and tore them down in clean() behind a bare `except AttributeError: pass`, so two EvoLearner instances used concurrently (e.g. fit() calls interleaved across threads) could silently clobber each other's DEAP type definitions. Each instance now suffixes its creator type names with a per-instance uuid.

Prunes the fixed item from Improvements.md §1 and records the fix in CHANGELOG.md, per repo convention.