### PR TITLE
Fix NCESTrainer DataLoader worker-pool deadlock under coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ date) and use that section as the basis for the GitHub release notes.
   by default, matching the other learners. (#585)
 
 ### Fixed
+- `NCESTrainer.train()` created a fresh `DataLoader(num_workers=...)` worker
+  pool per architecture in a loop; the existing `os.cpu_count()`-based cap on
+  `num_workers` only engaged when `cpu_count <= num_workers`, so it silently
+  did nothing on machines with more cores than the default of 8, and repeated
+  worker-pool creation at that count could deadlock under `coverage run`
+  (`NCES`/`NCES2`/`ROCES` training, e.g. `test_nces_trainer.py`). Now capped
+  unconditionally to `min(requested, cpu_count-1, 4)`. (#610)
 - `ConceptAbstractSyntaxTreeBuilder._fix_mid_tokens_errors`/`_postprocess_tail_fix`/
   `_enforce` repaired malformed token sequences via `random.choice(...)`, making
   parser output non-deterministic across runs on identical input; replaced with

--- a/ontolearn/learners/nces.py
+++ b/ontolearn/learners/nces.py
@@ -431,8 +431,12 @@ class NCES(BaseNCES):
               refinement_expressivity=0.2, refs_sample_size=50, learning_rate=1e-4, tmax=20, eta_min=1e-5,
               clip_value=5.0, num_workers=8, save_model=True, storage_path=None, optimizer='Adam', record_runtime=True,
               example_sizes=None, shuffle_examples=False):
-        if os.cpu_count() <= num_workers:
-            num_workers = max(0,os.cpu_count()-1)
+        # Cap unconditionally: on machines with many cores this previously stayed
+        # uncapped at the requested value, and repeatedly spawning that many
+        # DataLoader worker processes (one fresh pool per architecture in
+        # NCESTrainer.train()) can deadlock under `coverage run` regardless of
+        # how many cores are available (see issue #610).
+        num_workers = max(0, min(num_workers, (os.cpu_count() or 1) - 1, 4))
         if storage_path is None:
             currentDateAndTime = datetime.now()
             storage_path = f'NCES-Experiment-{currentDateAndTime.strftime("%H-%M-%S")}'

--- a/ontolearn/nces_trainer.py
+++ b/ontolearn/nces_trainer.py
@@ -60,7 +60,11 @@ class NCESTrainer:
         self.tmax = tmax
         self.eta_min = eta_min
         self.clip_value = clip_value
-        self.num_workers = num_workers
+        # Cap unconditionally, not just on low-core machines: train() spawns a
+        # fresh DataLoader worker pool per architecture in a loop, and doing so
+        # repeatedly with a large num_workers can deadlock under `coverage run`
+        # regardless of how many cores are available (see issue #610).
+        self.num_workers = max(0, min(num_workers, (os.cpu_count() or 1) - 1, 4))
         self.storage_path = storage_path
 
     @staticmethod


### PR DESCRIPTION
## Summary
- `NCESTrainer.train()` creates a fresh `DataLoader(num_workers=...)` worker pool per architecture in a loop over `self.synthesizer.model`. The existing `os.cpu_count()`-based cap on `num_workers` only engaged when `cpu_count <= num_workers`, so on any machine with more cores than the default of 8 it silently did nothing — the requested value passed straight through uncapped.
- Reproduced locally: `coverage run -m pytest` against `tests/test_nces_trainer.py` hung indefinitely with `num_workers=8` — confirmed via `/proc/<pid>/wchan` showing genuine `futex_wait_queue`/`unix_stream_data_wait`/`do_poll` blocking (a real deadlock, not slow computation: main process CPU time moved ~1s over 8 minutes of wall time). `num_workers` of 1/2/4 all completed reliably in under a minute under the same conditions.
- This matches the multi-hour CI hangs observed on PR #607's runs (`tests/test_nces_trainer.py` is where the CI job stalled). Full root-cause writeup in #610.
- Fix: cap `num_workers` unconditionally to `min(requested, cpu_count-1, 4)` in both `NCES.train()` (`ontolearn/learners/nces.py`) and `NCESTrainer.__init__` (`ontolearn/nces_trainer.py`, defense in depth for direct `NCESTrainer` usage bypassing `NCES.train()`).

Fixes #610.

## Test plan
- [x] `tests/test_nces_trainer.py` (previously hung 40+ min under `coverage run`, now passes in ~30-45s) — verified both in isolation and as part of the full suite.
- [x] Full local suite (`coverage run -m pytest -p no:warnings -x --durations=0`, CI-equivalent command) against a full local mirror of the CI environment (live Fuseki + mutagenesis dataset, KGs/LPs/NCESData/CLIPData present, clean venv matching `pip install -e .["full"]`): **191 passed in 20:48**, no hangs, no failures.
- [x] `coverage report -m` runs cleanly afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iKbU9gaut8SBBPnXcZhZA