### PR TITLE
Deduplicate quality_funcs f1/acc against metrics.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ date) and use that section as the basis for the GitHub release notes.
   `F`) instead of relying on ruff's shipped default. (#594)
 
 ### Changed
+- `quality_funcs.f1`/`acc` reimplemented the tp/tn/fp/fn and precision/recall
+  arithmetic already implemented in `metrics.py`'s `F1`/`Accuracy` classes; now
+  delegate to those classes instead of duplicating the math.
 - Ruff upgraded to `>=0.16.0`. (#594)
 - `TDL`/`TDL_refinement` data-property filtering extended to exclude boolean
   data properties, with a toggle to enable/disable boolean data properties.

--- a/Improvements.md
+++ b/Improvements.md
@@ -31,10 +31,6 @@ broader refactor.
   remove on the order of 300 duplicated lines. (`OCEL(CELOE)` in
   `ontolearn/learners/celoe.py`/`ocel.py` is a good counter-example of doing
   this inheritance correctly — worth using as the template.)
-- **`ontolearn/quality_funcs.py:31-56`** duplicates the tp/tn/fp/fn and
-  precision/recall math already implemented in `ontolearn/metrics.py:67-92`'s
-  `F1`/`Accuracy` classes. Have `quality_funcs.py` delegate to those classes
-  instead of reimplementing the arithmetic.
 - **`ontolearn/knowledge_base.py:191-262`** — `abox()` repeats the same
   triple-traversal ~70 lines of near-identical branching, once per
   `mode in {"native", "iri", "axiom"}`, differing only in output formatting.

--- a/ontolearn/quality_funcs.py
+++ b/ontolearn/quality_funcs.py
@@ -25,48 +25,32 @@
 from typing import Set
 from owlapy.class_expression import OWLClassExpression
 from ontolearn.abstracts import EncodedLearningProblem, AbstractScorer, AbstractKnowledgeBase
+from ontolearn.metrics import F1 as _F1, Accuracy as _Accuracy
 from ontolearn.search import EvaluatedConcept
 
 
-def f1(*, individuals: Set, pos: Set, neg: Set):
+def _tp_tn_fp_fn(individuals: Set, pos: Set, neg: Set):
     assert isinstance(individuals, set)
     assert isinstance(pos, set)
     assert isinstance(neg, set)
 
     tp = len(pos.intersection(individuals))
     tn = len(neg.difference(individuals))
-
     fp = len(neg.intersection(individuals))
     fn = len(pos.difference(individuals))
+    return tp, tn, fp, fn
 
-    try:
-        recall = tp / (tp + fn)
-    except ZeroDivisionError:
-        return 0
 
-    try:
-        precision = tp / (tp + fp)
-    except ZeroDivisionError:
-        return 0
-
-    if precision == 0 or recall == 0:
-        return 0
-
-    f_1 = 2 * ((precision * recall) / (precision + recall))
-    return f_1
+def f1(*, individuals: Set, pos: Set, neg: Set):
+    tp, tn, fp, fn = _tp_tn_fp_fn(individuals, pos, neg)
+    applicable, score = _F1().score2(tp=tp, fn=fn, fp=fp, tn=tn)
+    return score if applicable else 0
 
 
 def acc(*, individuals: Set, pos: Set, neg: Set):
-    assert isinstance(individuals, set)
-    assert isinstance(pos, set)
-    assert isinstance(neg, set)
-
-    tp = len(pos.intersection(individuals))
-    tn = len(neg.difference(individuals))
-
-    fp = len(neg.intersection(individuals))
-    fn = len(pos.difference(individuals))
-    return (tp + tn) / (tp + tn + fp + fn)
+    tp, tn, fp, fn = _tp_tn_fp_fn(individuals, pos, neg)
+    _, score = _Accuracy().score2(tp=tp, fn=fn, fp=fp, tn=tn)
+    return score
 
 
 def evaluate_concept(kb: AbstractKnowledgeBase, concept: OWLClassExpression, quality_func: AbstractScorer,


### PR DESCRIPTION
## Summary
- `quality_funcs.f1`/`acc` reimplemented the tp/tn/fp/fn and precision/recall
  arithmetic already implemented by `metrics.py`'s `F1`/`Accuracy` classes.
  Both now delegate to those classes instead of duplicating the math.
- Prunes the corresponding item from `Improvements.md` (§2 Code duplication).
- Adds a `CHANGELOG.md` entry.

## Test plan
- [x] `pytest tests/test_metrics.py` passes
- [x] `ruff check ontolearn/learners --exclude ontolearn/learners/spell_kit --line-length=200` passes
- [x] Manual sanity check: `f1`/`acc` produce identical results to the prior implementation on a hand-computed tp/tn/fp/fn case, including the zero-division edge case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xuv1tiWYdtxTf2jhrSPWVa