### PR TITLE
Prune two Improvements.md duplication items already fixed on develop

### DIFF
--- a/Improvements.md
+++ b/Improvements.md
@@ -15,22 +15,6 @@ remain open as of this writing.
 
 ## 2. Code duplication
 
-- **`ontolearn/quality_funcs.py:31-56`** duplicates the tp/tn/fp/fn and
-  precision/recall math already implemented in `ontolearn/metrics.py:67-92`'s
-  `F1`/`Accuracy` classes. Have `quality_funcs.py` delegate to those classes
-  instead of reimplementing the arithmetic.
-- **`ontolearn/learners/tree_learner_refinement_inherit.py` vs
-  `tree_learner.py`** — `TDL_refinement(TDL)` is ~70% copy-pasted rather than
-  extended. `fit()` (tree_learner_refinement_inherit.py:604-761) duplicates
-  `TDL.fit()` (tree_learner.py:661-736) almost line-for-line (grid search,
-  classifier training, `report_classification`, plotting) with only the
-  refinement loop spliced in; `extract_expressions_from_owl_individuals`,
-  `create_training_data`, and `_extract_data_property_features` are likewise
-  wholesale overrides. A template-method refactor — pulling
-  `_train_classifier`/`_report`/`_plot` into the base `TDL` as hooks — would
-  remove on the order of 300 duplicated lines. (`OCEL(CELOE)` in
-  `ontolearn/learners/celoe.py`/`ocel.py` is a good counter-example of doing
-  this inheritance correctly — worth using as the template.)
 - **`ontolearn/knowledge_base.py:191-262`** — `abox()` repeats the same
   triple-traversal ~70 lines of near-identical branching, once per
   `mode in {"native", "iri", "axiom"}`, differing only in output formatting.


### PR DESCRIPTION
## Summary
- PR #616 (tree_learner_refinement dedup) and PR #615 (quality_funcs dedup) each correctly pruned their own item from `Improvements.md`'s §2 Code duplication in their branch commits.
- While #616 was in review, its branch was updated from `develop` via a merge commit (`2acaa0f`), which re-added *both* bullets to `Improvements.md` instead of keeping them removed — a bad conflict resolution, not a revert of either fix. That merge landed on `develop` as part of #616.
- Both underlying fixes are still present in the code:
  - `ontolearn/quality_funcs.py` still delegates to `metrics.py`'s `F1`/`Accuracy`.
  - `TDL_refinement.fit()`/`create_training_data()` are still deduplicated against `TDL` via the shared `_maybe_plot_embeddings`/`_fit_decision_tree`/`_report_and_plot`/`_finalize_predictions` hooks.
- This PR only corrects the stale doc — no code changes.

## Test plan
- [x] Diffed current `ontolearn/quality_funcs.py` and `ontolearn/learners/tree_learner*.py` on `develop` against the two PR descriptions to confirm both fixes are intact
- N/A for code — doc-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4NxQxE3vqNs2DQBWVaFeM