### PR TITLE
Fix #611: cache per-feature DL syntax in TDL_refinement._merge_binary_feature_matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ date) and use that section as the basis for the GitHub release notes.
   refinements on a given property were ever explored during search. `max_nr_fillers`
   is now a lazily-populated mapping (`_LazyMaxNrFillers`) that computes and caches a
   property's value on first lookup instead. (#612)
+- `TDL_refinement._merge_binary_feature_matrices` re-rendered each candidate
+  feature's DL syntax string from scratch inside the per-example loop
+  (`owl_expression_to_dl` scales with expression complexity), giving
+  O(examples × features × expression-size) work instead of O(features ×
+  expression-size); now precomputed once per feature before the example
+  loop. (#611)
 - `TDL_refinement.fit()` (`ontolearn/learners/tree_learner_refinement_inherit.py`)
   duplicated `TDL.fit()` (`ontolearn/learners/tree_learner.py`) almost
   line-for-line for grid search, classifier training, classification

--- a/ontolearn/learners/tree_learner_refinement_inherit.py
+++ b/ontolearn/learners/tree_learner_refinement_inherit.py
@@ -549,6 +549,7 @@ class TDL_refinement(TDL):
     def _merge_binary_feature_matrices(self, lp: PosNegLPStandard, X: pd.DataFrame, new_features: list, new_individuals_to_feature_mapping) -> pd.DataFrame:
         """Merge the original binary feature matrix with new features extracted from data properties."""
         new_features_list = [v for k, v in new_features.items()]
+        dl_by_feature = {f: owl_expression_to_dl(f) for f in new_features_list}
         positive_examples = [i for i in lp.pos]
         negative_examples = [i for i in lp.neg]
         examples = positive_examples + negative_examples
@@ -559,7 +560,7 @@ class TDL_refinement(TDL):
             if owl_named_individual.str in new_individuals_to_feature_mapping:
                 features_of_owl_named_individual = new_individuals_to_feature_mapping[owl_named_individual.str]
             for owl_class_expression in new_features_list:
-                if features_of_owl_named_individual is not None and owl_expression_to_dl(owl_class_expression) in features_of_owl_named_individual:
+                if features_of_owl_named_individual is not None and dl_by_feature[owl_class_expression] in features_of_owl_named_individual:
                     binary_sparse_representation.append(1.0)
                 else:
                     binary_sparse_representation.append(0.0)


### PR DESCRIPTION
## Summary
- `TDL_refinement._merge_binary_feature_matrices` re-rendered each candidate feature's DL syntax string from scratch inside the innermost (per-example) loop, giving O(examples × features × expression-size) work instead of O(features × expression-size). `owl_expression_to_dl` recursively walks the expression tree so its cost scales with expression complexity.
- Precompute `dl_by_feature = {f: owl_expression_to_dl(f) for f in new_features_list}` once before the example loop and look up from that dict inside the loop, as suggested in the issue.
- Added a CHANGELOG.md entry under `[Unreleased] / Changed`.

Fixes #611

## Test plan
- [x] `ruff check ontolearn/learners/tree_learner_refinement_inherit.py --line-length=200` passes
- [ ] `pytest tests/test_tdl_refinement.py` — could not run in this environment due to a pre-existing, unrelated `pandas`/`bottleneck` ABI mismatch (`AttributeError: _ARRAY_API not found`) that reproduces on `develop` as well, before this change. Please run CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhnPY616ht2DRE275DuCE